### PR TITLE
Fix aarch64 C library loading

### DIFF
--- a/hikvision-sdk/Dockerfile
+++ b/hikvision-sdk/Dockerfile
@@ -1,25 +1,20 @@
-# The build variables are populated by Home Assistant during the image build
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM python:3.10.8-slim
 
+# The build arguments are populated by Home Assistant during the image build
 # Use this build argument to know for which platform we are building
 ARG BUILD_ARCH
 
 WORKDIR /app
-RUN echo "Installing dependencies for ${BUILD_ARCH}"
+RUN echo "Building for ${BUILD_ARCH}"
 
-# Check the architecture for which we are building, and use the appropriate packaging tool to install the dependencies
-RUN if [ ${BUILD_ARCH} = "i386" ] || [ ${BUILD_ARCH} = "amd64" ]; then \
-        # Debian based system
-        apt-get update && apt-get install -y libffi-dev; \
-    else \
-        # openeuler OS
-        yum -y install python-pip; \
-    fi
+# Install the required dependencies from the package manager
+RUN apt-get update \
+    && apt-get install -y libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Hikvision SDK
 COPY lib-${BUILD_ARCH} /app/lib-${BUILD_ARCH}
@@ -27,4 +22,11 @@ COPY lib-${BUILD_ARCH} /app/lib-${BUILD_ARCH}
 # Main application
 COPY src/*.py /app/
 
-ENTRYPOINT [ "python3", "/app/hik.py" ]
+# Enable python module to get stacktraces from C native calls
+ENV PYTHONFAULTHANDLER=true
+# Required env variable to load Hikvision ssl and crypto libraries instead of system libraries
+ENV LD_LIBRARY_PATH=/app/lib-${BUILD_ARCH}
+
+ENTRYPOINT [ "python3"]
+
+CMD ["/app/hik.py" ]

--- a/hikvision-sdk/build.yaml
+++ b/hikvision-sdk/build.yaml
@@ -1,5 +1,0 @@
-build_from:
-  i386: library/python:3.10.8-slim
-  amd64: library/python:3.10.8-slim
-  # Hikvision SDK requires this particular base os to run on aarch64 machines (RPi)
-  aarch64: openeuler/openeuler:22.03-lts-sp1

--- a/hikvision-sdk/development.env.example
+++ b/hikvision-sdk/development.env.example
@@ -5,3 +5,9 @@ USERNAME=admin
 PASSWORD=admin
 
 LOG_LEVEL=DEBUG
+
+# To load C native libraries required by the Hikvision SDK. Use the folder depending on you architecture 
+LD_LIBRARY_PATH=lib-amd64/
+
+# Enable python module to get stacktraces from C native calls
+PYTHONFAULTHANDLER=true

--- a/hikvision-sdk/docker-compose.yml
+++ b/hikvision-sdk/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  doorbell:
+    build:
+      args:       
+        # Change this according to your architecture (so the correct native C libraries are used)
+        - BUILD_ARCH=amd64
+        # - BUILD_ARCH=aarch64
+      context: .
+    env_file:
+      # Create a copy of development.env.example and set your variables accordingly
+      - development.env
+    tty: true   # To read stdin commands
+    network_mode: "host"

--- a/hikvision-sdk/docs/docker.md
+++ b/hikvision-sdk/docs/docker.md
@@ -1,15 +1,16 @@
 # Running the addon locally with Docker
 
-Run the following from the `hikvision-sdk` folder:
+There is a `docker-compose.yml` provided showing how to setup the required build args.
 
-- build the image, specifying the base image, based on your architecture (see `build.yaml` for references to which base image to use).
+To manually build and run the container, run the following from the `hikvision-sdk` folder:
+
+- Build the image, specifying your architecture.
 For instance:
 ```bash
-docker build --build-arg=BUILD_FROM=library/python:3.10.8-slim --build-arg=BUILD_ARCH=amd64 -t hikvision-sdk .
+docker build --build-arg=BUILD_ARCH=amd64 -t hikvision-sdk .
 ```
 
-- Run a container using the built image (remember to set the required environment variables!)
-For instance:
+- Run a container from the built image (set the required environment variables)
 ```bash
 docker run -e IP=192.168.0.250 hikvision-sdk
 ```


### PR DESCRIPTION
- The libraries provided by Hikvision SDK are loaded instead of the system ones by specifying the env variable `LD_LIBRARY_PATH`. 
This fix allows to use the base Docker Python image also for aarch64 builds.

- Add `docker-compose.yml` file to ease in local development with service containers
- Remove `BUILD_FROM` arg in Dockerfile, since the base image now is always Python