### PR TITLE
Automate Docker image build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,20 +9,28 @@ on:
 
 
 jobs:
+  # Remove the prefix `doorbell-v` from the Git tag and set it as output of this step
+  extract-version:
+    name: Extract version from tag
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
+    steps:
+      - name: Extract version
+        id: extract_version
+        run: |
+          echo ${{ github.ref_name }} | sed -nr 's/doorbell-v(.*)/version=\1/p' >> $GITHUB_OUTPUT
+
   docker-image_amd64:
     name: Docker image (amd64)
     runs-on: ubuntu-latest
+    needs: ["extract-version"]
     permissions:
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
-        # Remove the prefix `doorbell-v` from the Git tag and set it as output of this step
-      - name: Extract Docker tag
-        id: extract_docker_tag
-        run: |
-          echo ${{ github.ref_name }} | sed -nr 's/doorbell-v(.*)/version=\1/p' >> $GITHUB_OUTPUT
 
       - name: Docker metadata
         id: meta
@@ -36,15 +44,17 @@ jobs:
             # define match group
             type=match,pattern=doorbell-v(.*),group=1
           # Append architecture to generated tag
-          flavor:
+          # Disable latest tag
+          flavor: |
+            latest=false
             suffix=-amd64
           labels: |
             org.opencontainers.image.title=Hikvision Doorbell
             # Custom label required by Home Assistant supervisor
              #https://developers.home-assistant.io/docs/add-ons/configuration?_highlight=add&_highlight=on&_highlight=label#add-on-dockerfile
-            io.hass.version=${{ steps.extract_docker_tag.outputs.version }}
-            io.hass.type="addon"
-            io.hass.arch="amd64"
+            io.hass.version=${{ needs.extract-version.outputs.version }}
+            io.hass.type=addon
+            io.hass.arch=amd64
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -67,21 +77,19 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Disable provenance, since it creates problem with docker manifests
+          # https://github.com/docker/build-push-action/releases/tag/v4.0.0
+          provenance: false
 
   docker-image_aarch64:
     name: Docker image (aarch64)
     runs-on: ubuntu-latest
+    needs: ["extract-version"]
     permissions:
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
-        # Remove the prefix `doorbell-v` from the Git tag and set it as output of this step
-      - name: Extract Docker tag
-        id: extract_docker_tag
-        run: |
-          echo ${{ github.ref_name }} | sed -nr 's/doorbell-v(.*)/version=\1/p' >> $GITHUB_OUTPUT
 
       - name: Docker metadata
         id: meta
@@ -95,15 +103,17 @@ jobs:
             # define match group
             type=match,pattern=doorbell-v(.*),group=1
           # Append architecture to generated tag
-          flavor:
+          # Disable latest tag
+          flavor: |
+            latest=false
             suffix=-aarch64
           labels: |
             org.opencontainers.image.title=Hikvision Doorbell
             # Custom label required by Home Assistant supervisor
              #https://developers.home-assistant.io/docs/add-ons/configuration?_highlight=add&_highlight=on&_highlight=label#add-on-dockerfile
-            io.hass.version=${{ steps.extract_docker_tag.outputs.version }}
-            io.hass.type="addon"
-            io.hass.arch="aarch64"
+            io.hass.version=${{ needs.extract-version.outputs.version }}
+            io.hass.type=addon
+            io.hass.arch=aarch64
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -126,11 +136,14 @@ jobs:
           platforms: linux/aarch64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Disable provenance, since it creates problem with docker manifests
+          # https://github.com/docker/build-push-action/releases/tag/v4.0.0
+          provenance: false
 
   update-manifest:
     name: Update Docker image manifest
     runs-on: ubuntu-latest
-    needs: [docker-image_amd64, docker-image_aarch64]
+    needs: [extract-version, docker-image_amd64, docker-image_aarch64]
     permissions:
       packages: write
     steps:
@@ -143,9 +156,7 @@ jobs:
 
       - name: Update image manifest and push it
         run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo ${{ github.ref_name }} | sed -nr 's/doorbell-v(.*)/version=\1/p')
-
+          VERSION=${{ needs.extract-version.outputs.version }}
           echo VERSION=$VERSION
 
           # Create a single manifest from the two images

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,158 @@
+# This workflow will publish the Docker image built in a previous job on Github container registry
+
+name: Deploy Docker image
+
+on:
+  push:
+    tags:
+      - "doorbell-v*"
+
+
+jobs:
+  docker-image_amd64:
+    name: Docker image (amd64)
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+        # Remove the prefix `doorbell-v` from the Git tag and set it as output of this step
+      - name: Extract Docker tag
+        id: extract_docker_tag
+        run: |
+          echo ${{ github.ref_name }} | sed -nr 's/doorbell-v(.*)/version=\1/p' >> $GITHUB_OUTPUT
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/hikvision-doorbell
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            # define match group
+            type=match,pattern=doorbell-v(.*),group=1
+          # Append architecture to generated tag
+          flavor:
+            suffix=-amd64
+          labels: |
+            org.opencontainers.image.title=Hikvision Doorbell
+            # Custom label required by Home Assistant supervisor
+             #https://developers.home-assistant.io/docs/add-ons/configuration?_highlight=add&_highlight=on&_highlight=label#add-on-dockerfile
+            io.hass.version=${{ steps.extract_docker_tag.outputs.version }}
+            io.hass.type="addon"
+            io.hass.arch="amd64"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and export
+        uses: docker/build-push-action@v4
+        with:
+          context: ./hikvision-doorbell
+          file: ./hikvision-doorbell/Dockerfile
+          build-args: |
+            BUILD_ARCH=amd64
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-image_aarch64:
+    name: Docker image (aarch64)
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+        # Remove the prefix `doorbell-v` from the Git tag and set it as output of this step
+      - name: Extract Docker tag
+        id: extract_docker_tag
+        run: |
+          echo ${{ github.ref_name }} | sed -nr 's/doorbell-v(.*)/version=\1/p' >> $GITHUB_OUTPUT
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/hikvision-doorbell
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            # define match group
+            type=match,pattern=doorbell-v(.*),group=1
+          # Append architecture to generated tag
+          flavor:
+            suffix=-aarch64
+          labels: |
+            org.opencontainers.image.title=Hikvision Doorbell
+            # Custom label required by Home Assistant supervisor
+             #https://developers.home-assistant.io/docs/add-ons/configuration?_highlight=add&_highlight=on&_highlight=label#add-on-dockerfile
+            io.hass.version=${{ steps.extract_docker_tag.outputs.version }}
+            io.hass.type="addon"
+            io.hass.arch="aarch64"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and export
+        uses: docker/build-push-action@v4
+        with:
+          context: ./hikvision-doorbell
+          file: ./hikvision-doorbell/Dockerfile
+          build-args: |
+            BUILD_ARCH=aarch64
+          push: true
+          platforms: linux/aarch64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  update-manifest:
+    name: Update Docker image manifest
+    runs-on: ubuntu-latest
+    needs: [docker-image_amd64, docker-image_aarch64]
+    permissions:
+      packages: write
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update image manifest and push it
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo ${{ github.ref_name }} | sed -nr 's/doorbell-v(.*)/version=\1/p')
+
+          echo VERSION=$VERSION
+
+          # Create a single manifest from the two images
+          docker manifest create \
+            ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION \
+            --amend ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION-amd64 \
+            --amend ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION-aarch64
+          
+          # Push the updated manifest
+          docker manifest push ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: read
 
+# To cancel a currently running workflow from the same PR, branch or tag when a new workflow is triggered you can use:
+# Taken from https://stackoverflow.com/a/72408109
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -60,7 +66,7 @@ jobs:
           outputs: |
             type=docker,dest=/tmp/image.tar
           platforms: linux/amd64
-          tags: ${{github.repository_owner}}/hikvision-doorbell:latest
+          tags: hikvision-doorbell:latest
       
       - name: Upload image
         uses: actions/upload-artifact@v3
@@ -90,7 +96,7 @@ jobs:
           outputs: |
             type=docker,dest=/tmp/image.tar
           platforms: linux/arm64
-          tags: ${{github.repository_owner}}/hikvision-doorbell:latest
+          tags: hikvision-doorbell:latest
 
       - name: Upload image
         uses: actions/upload-artifact@v3
@@ -121,7 +127,7 @@ jobs:
           SYSTEM__LOG_LEVEL: DEBUG
           SYSTEM__SDK_LOG_LEVEL: DEBUG
         run: |
-          echo -n "" | docker run -i -e SYSTEM__LOG_LEVEL -e SYSTEM__SDK_LOG_LEVEL ${{github.repository_owner}}/hikvision-doorbell:latest
+          echo -n "" | docker run -i -e SYSTEM__LOG_LEVEL -e SYSTEM__SDK_LOG_LEVEL hikvision-doorbell:latest
 
   test-image-aarch64:
     runs-on: ubuntu-latest
@@ -177,4 +183,37 @@ jobs:
             docker image ls -a
             echo "Loaded image.tar"
 
-            echo -n "" | docker run -i -e SYSTEM__LOG_LEVEL -e SYSTEM__SDK_LOG_LEVEL ${{github.repository_owner}}/hikvision-doorbell:latest
+            echo -n "" | docker run -i -e SYSTEM__LOG_LEVEL -e SYSTEM__SDK_LOG_LEVEL hikvision-doorbell:latest
+
+  
+  # deploy-update-manifest:
+  #   name: Update Docker image manifest
+  #   runs-on: ubuntu-latest
+  #   needs: [deploy-workflow_amd64, deploy-workflow_aarch64]
+  #   permissions:
+  #     packages: write
+  #   steps:
+  #     - name: Login to GitHub Container Registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Update image manifest and push it
+  #       run: |
+  #         # Strip git ref prefix from version
+  #         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+  #         # Strip "v" prefix from tag name
+  #         [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+  #         echo VERSION=$VERSION
+
+  #         # Create a single manifest from the two images
+  #         docker manifest create \
+  #           ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION \
+  #           --amend ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION-amd64 \
+  #           --amend ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION-aarch64
+          
+  #         # Push the updated manifest
+  #         docker manifest push ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -185,35 +185,3 @@ jobs:
 
             echo -n "" | docker run -i -e SYSTEM__LOG_LEVEL -e SYSTEM__SDK_LOG_LEVEL hikvision-doorbell:latest
 
-  
-  # deploy-update-manifest:
-  #   name: Update Docker image manifest
-  #   runs-on: ubuntu-latest
-  #   needs: [deploy-workflow_amd64, deploy-workflow_aarch64]
-  #   permissions:
-  #     packages: write
-  #   steps:
-  #     - name: Login to GitHub Container Registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Update image manifest and push it
-  #       run: |
-  #         # Strip git ref prefix from version
-  #         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-  #         # Strip "v" prefix from tag name
-  #         [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-  #         echo VERSION=$VERSION
-
-  #         # Create a single manifest from the two images
-  #         docker manifest create \
-  #           ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION \
-  #           --amend ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION-amd64 \
-  #           --amend ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION-aarch64
-          
-  #         # Push the updated manifest
-  #         docker manifest push ghcr.io/${{ github.repository_owner }}/hikvision-doorbell:$VERSION


### PR DESCRIPTION
Add Github workflow to automatically build and publish a Docker image in the Github container registry.
The workflow is triggered by a Git tag starting with `doorbell-v` + `release version`, to distinguish between `doorbell` and `sip` addon releases.
For instance `doorbell-v3.0.0-beta1`

Fixes #67 