### PR TITLE
Remove options to personalize sensor names

### DIFF
--- a/hikvision-doorbell/DOCS.md
+++ b/hikvision-doorbell/DOCS.md
@@ -30,17 +30,6 @@ doorbells:
     password: password
 ```
 
-### Sensors
-Configure the name of the sensors that are created in Home Assistant.
-
-| Name              | Default               | Description                           |
-| --------          | ----                  | ----                                  |
-| sensor_callstatus | hikvision_callstatus  | Call status event
-| sensor_dimiss     | hikvision_dismiss     | Call dismissed event
-| sensor_motion     | hikvision_motion      | Motion detection alarm
-| sensor_door       | hikvision_door        | Door open event
-| sensor_tamper     | hikvision_tamper      | Tamper alarm
-
 ### General
 The following settings are also available:
 

--- a/hikvision-doorbell/config.yaml
+++ b/hikvision-doorbell/config.yaml
@@ -21,12 +21,6 @@ options:
       ip: null
       username: admin
       password: ""
-  sensors:
-    door: door
-    callstatus: callstatus
-    motion: motion
-    tamper: tamper
-    dismiss: dismiss
   home_assistant:
     url: "http://supervisor/core"
   system:

--- a/hikvision-doorbell/default_config.yaml
+++ b/hikvision-doorbell/default_config.yaml
@@ -12,14 +12,6 @@ doorbells: []
 #     username: admin
 #     password: password
 
-# Name of the sensors created inside Home Assistant
-sensors:
-  door: door
-  callstatus: callstatus
-  motion: motion
-  tamper: tamper
-  dismiss: dismiss
-
 # Define the following options to enable the Home Assistant API integration
 # home_assistant:
 #   url: http://localhost:8123

--- a/hikvision-doorbell/docker-compose.yml
+++ b/hikvision-doorbell/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # Create a copy of development.env.example and set your variables accordingly
       - development.env
     tty: true   # To read stdin commands
-    # network_mode: "host"
+    network_mode: "host"
 
   home-assistant:
     container_name: home-assistant

--- a/hikvision-doorbell/src/config.py
+++ b/hikvision-doorbell/src/config.py
@@ -33,13 +33,6 @@ class AppConfig(GoodConf):
         username: str
         password: str
 
-    class Sensors(BaseModel):
-        door: str
-        callstatus: str
-        motion: str
-        tamper: str
-        dismiss: str
-
     class HomeAssistant(BaseModel):
         url: AnyHttpUrl = Field(description="Base url of Home Assistant")
         # Cannot load directly SUPERVISOR_TOKEN env variable here, since it is not supported by Pydantic
@@ -67,7 +60,6 @@ class AppConfig(GoodConf):
             return level
 
     doorbells: list[Doorbell] = Field(description="List of doorbells to connect to")
-    sensors: Sensors
     home_assistant: Optional[HomeAssistant]
     system: System
 

--- a/hikvision-doorbell/src/home_assistant.py
+++ b/hikvision-doorbell/src/home_assistant.py
@@ -35,7 +35,7 @@ class HomeAssistantAPI(EventHandler):
     name = "HomeAssistantAPI"
     _sensors: dict[str, Sensor] = {}
 
-    def __init__(self, sensors: AppConfig.Sensors, config: AppConfig.HomeAssistant, doorbells: Registry) -> None:
+    def __init__(self, config: AppConfig.HomeAssistant, doorbells: Registry) -> None:
         super().__init__()
         logger.info("Setting up event handler: Home Assistant API")
 
@@ -43,27 +43,27 @@ class HomeAssistantAPI(EventHandler):
         self._doorbells = doorbells
 
         self._sensors['door'] = Sensor(
-            name=sensors.door,
+            name="door",
             type="binary_sensor",
             attributes={"device_class": "door"}
         )
         self._sensors['callstatus'] = Sensor(
-            name=sensors.callstatus,
+            name="callstatus",
             type="binary_sensor",
             attributes={"device_class": "sound"}
         )
         self._sensors['motion'] = Sensor(
-            name=sensors.motion,
+            name="motion",
             type="binary_sensor",
             attributes={"device_class": "motion"}
         )
         self._sensors['tamper'] = Sensor(
-            name=sensors.tamper,
+            name='tamper',
             type="binary_sensor",
             attributes={"device_class": "tamper"}
         )
         self._sensors['dismiss'] = Sensor(
-            name=sensors.dismiss,
+            name='dismiss',
             type="binary_sensor",
             attributes={}
         )

--- a/hikvision-doorbell/src/main.py
+++ b/hikvision-doorbell/src/main.py
@@ -47,7 +47,7 @@ async def main():
     event_manager.register_handler(console)
 
     if config.home_assistant:
-        ha_api = HomeAssistantAPI(config.sensors, config.home_assistant, doorbell_registry)
+        ha_api = HomeAssistantAPI(config.home_assistant, doorbell_registry)
         event_manager.register_handler(ha_api)
 
     # Start listening for events

--- a/hikvision-doorbell/tests/assets/test_config.json
+++ b/hikvision-doorbell/tests/assets/test_config.json
@@ -7,13 +7,6 @@
           "password": ""
       }
   ],
-  "sensors": {
-      "door": "hikvision_door",
-      "callstatus": "hikvision_callstatus",
-      "motion": "hikvision_motion",
-      "tamper": "hikvision_tamper",
-      "dismiss": "hikvision_dismiss"
-  },
   "home_assistant": {
       "url": "http://supervisor/core",
       "token": "test_token"

--- a/hikvision-doorbell/tests/assets/test_config_wrong.json
+++ b/hikvision-doorbell/tests/assets/test_config_wrong.json
@@ -7,13 +7,6 @@
           "password": ""
       }
   ],
-  "sensors": {
-      "door": "hikvision_door",
-      "callstatus": "hikvision_callstatus",
-      "motion": "hikvision_motion",
-      "tamper": "hikvision_tamper",
-      "dismiss": "hikvision_dismiss"
-  },
   "home_assistant": {
       "url": "http://supervisor/core"
   },


### PR DESCRIPTION
Remove the options to customize sensor names.
The sensors are now named after the doorbell they are part of, and that options are no longer necessary and may confuse new users.