### PR TITLE
External broker settings

### DIFF
--- a/hikvision-doorbell/config.yaml
+++ b/hikvision-doorbell/config.yaml
@@ -22,7 +22,8 @@ options:
   system:
     log_level: INFO
     sdk_log_level: NONE
-
+  mqtt: {}
+ 
 # Schema for the options above
 schema:
   doorbells:
@@ -34,6 +35,12 @@ schema:
   system:
     log_level: match(^ERROR|WARNING|INFO|DEBUG$)
     sdk_log_level: match(^NONE|ERROR|INFO|DEBUG$)?
+  mqtt:
+    host: "str?"
+    port: "int?"
+    ssl: "bool?"
+    username: "str?"
+    password: "str?"
 
 # To request MQTT configuration using the supervisor API
 services:

--- a/hikvision-doorbell/docs/DEVELOPMENT.md
+++ b/hikvision-doorbell/docs/DEVELOPMENT.md
@@ -28,18 +28,14 @@ python src/main.py
 ```
 
 ## VSCode
-If using VSCode, there is a run configuration already provided.
-First create a `development.env` file with your own values
-```bash
-cp development.env.example development.env
-```
 
 - If using VSCode, there is a run configuration already provided.
-First create a `development.env` file with your own values, then run the application using the integrated VSCode debugger.
-```bash
-cp development.env.example development.env
-```
-Run the application using the integrated VSCode runner (under `Run and Debug`).
+    
+    First create a `development.env` file with your own values, then run the application using the integrated VSCode debugger.
+    ```bash
+    cp development.env.example development.env
+    ```
+- Run the application using the integrated VSCode runner (under `Run and Debug`).
 
 ## Testing the addon locally (VSCode devcontainer)
 For more information see the official HA [guide](https://developers.home-assistant.io/docs/add-ons/testing).

--- a/hikvision-doorbell/src/config.py
+++ b/hikvision-doorbell/src/config.py
@@ -115,7 +115,10 @@ class AppConfig(GoodConf):
         '''
         Load the MQTT configuration from the user-supplied values, if provided, or fallback to asking the HA supervisor for the integrated MQTT add-on
         '''
-
+        # If we have no value in input, skip validation
+        if not v:
+            return
+        
         # If the user supplied some configuration values, ues them
         if v:
             return v

--- a/hikvision-doorbell/src/config.py
+++ b/hikvision-doorbell/src/config.py
@@ -116,7 +116,7 @@ class AppConfig(GoodConf):
         Load the MQTT configuration from the user-supplied values, if provided, or fallback to asking the HA supervisor for the integrated MQTT add-on
         '''
         # If we have no value in input, skip validation
-        if not v:
+        if v is None:
             return
         
         # If the user supplied some configuration values, ues them

--- a/hikvision-doorbell/src/main.py
+++ b/hikvision-doorbell/src/main.py
@@ -17,9 +17,13 @@ from input import InputReader
 async def main():
     """Main entrypoint of the application"""
 
-    # Disable type warnings since the object is populated at runtime using goodconf library
-    config = AppConfig()  # type:ignore
-    config.load()
+    try:
+        # Disable type warnings since the object is populated at runtime using goodconf library
+        config = AppConfig()  # type:ignore
+        config.load()
+    except RuntimeError as e:
+        logger.error("Configuration error: {}", e)
+        sys.exit(1)
 
     # Remove the default handler installed by loguru (it redirects to stderr)
     logger.remove()
@@ -96,7 +100,7 @@ if __name__ == "__main__":
         user_message, sdk_code, sdk_message = e.args
         logger.error("{}: {} Error code:{}", user_message, sdk_message, sdk_code)
         sys.exit(1)
-    except (ConnectionRefusedError, socket.gaierror) as e:
+    except (OSError, ConnectionRefusedError) as e:
         # Connection to MQTT broker failed
         logger.error("Error while connecting to MQTT broker: {}", e.strerror)
         sys.exit(1)

--- a/hikvision-doorbell/src/main.py
+++ b/hikvision-doorbell/src/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import signal
+import socket
 import sys
 from config import AppConfig
 from doorbell import Doorbell, Registry
@@ -94,4 +95,8 @@ if __name__ == "__main__":
         # <user_message> <sdk_message> <sdk_code>
         user_message, sdk_code, sdk_message = e.args
         logger.error("{}: {} Error code:{}", user_message, sdk_message, sdk_code)
+        sys.exit(1)
+    except (ConnectionRefusedError, socket.gaierror) as e:
+        # Connection to MQTT broker failed
+        logger.error("Error while connecting to MQTT broker: {}", e.strerror)
         sys.exit(1)

--- a/hikvision-doorbell/tests/test_config.py
+++ b/hikvision-doorbell/tests/test_config.py
@@ -22,3 +22,5 @@ def test_load_config_missing_token():
 def test_load_config_mqtt():
     config = AppConfig()  # type: ignore
     config.load("tests/assets/test_config_mqtt.json")
+    assert config.mqtt.host is not None
+    assert config.mqtt.port is not None

--- a/hikvision-doorbell/translations/en.yaml
+++ b/hikvision-doorbell/translations/en.yaml
@@ -9,3 +9,8 @@ configuration:
     name: "System options"
     description: >-
       Configure general options for the add-on itself, such as its logs. See the 'Documentation' tab for more details.
+
+  mqtt:
+    name: "MQTT broker"
+    description: >-
+      Optional settings to configure the connection to an external broker. By default the add-on auto-discovers the Mosquitto add-on, if available.


### PR DESCRIPTION
Allow the user of the add-on to use an external MQTT broker.
I cannot test this in my local environment due to an issue with the upstream VSCode devcontainer, so I am not 100% sure it works as designed.

Fixes #93 