### PR TITLE
Add dynamic ports for 8000 and 1883

### DIFF
--- a/hikvision-doorbell/config.yaml
+++ b/hikvision-doorbell/config.yaml
@@ -29,6 +29,7 @@ schema:
   doorbells:
     - name: str
       ip: str
+      port: "int?"
       username: str
       password: str
       output_relays: "int?"

--- a/hikvision-doorbell/default_config.yaml
+++ b/hikvision-doorbell/default_config.yaml
@@ -9,6 +9,7 @@ doorbells: []
 # Uncomment the following lines and define each doorbell by repeating the example config:
 #   - name: "Front porch"
 #     ip: 192.168.0.1
+#     port: 8000
 #     username: admin
 #     password: password
 
@@ -20,8 +21,8 @@ doorbells: []
 # Define the following options to enable the MQTT integration
 # mqtt:
 #   host: localhost
-#   port: 1883
 #   # Optionals settings:
+#   port: 1883
 #   ssl: <boolean>  # Set to true to enable SSL
 #   username: <user>
 #   password: <password>

--- a/hikvision-doorbell/development.env.example
+++ b/hikvision-doorbell/development.env.example
@@ -1,7 +1,8 @@
 # Example .env files for local development. Make a copy of it and set your own parameters
 
 # JSON-encoded string containing the list of doorbells to connect to
-DOORBELLS=[{"name":"outdoor", "ip": "192.168.0.1", "username": "user", "password": "password"}]
+
+DOORBELLS=[{"name":"outdoor", "ip": "192.168.0.1", "port": 8000, "username": "user", "password": "password"}]
 
 # Connection to Home Assistant API (deprecated, use MQTT instead)
 # HOME_ASSISTANT__URL=http://localhost:8123
@@ -10,6 +11,7 @@ DOORBELLS=[{"name":"outdoor", "ip": "192.168.0.1", "username": "user", "password
 # Connection to MQTT broker
 MQTT__HOST=localhost
 # Optionals:
+MQTT__PORT=1883
 MQTT__USERNAME=<username>
 MQTT__PASSWORD=<password>
 

--- a/hikvision-doorbell/docs/docker.md
+++ b/hikvision-doorbell/docs/docker.md
@@ -16,11 +16,12 @@ services:
     tty: true   # To receive commands on STDIN
     env:
         # JSON string with the list of doorbells
-        DOORBELLS: '[{"name":"outdoor", "ip": "192.168.0.1", "username": "user", "password": "password"}]'
+        DOORBELLS: '[{"name":"outdoor", "ip": "192.168.0.1", "port": 8000, "username": "user", "password": "password"}]'
         
         # Connection to the MQTT broker
         MQTT__HOST: <hostname_of_broker>
         # Optionals
+        MQTT__PORT: 1883
         MQTT__USERNAME: <broker_username>
         MQTT__PASSWORD: <broker_password>
         

--- a/hikvision-doorbell/src/config.py
+++ b/hikvision-doorbell/src/config.py
@@ -67,6 +67,7 @@ class AppConfig(GoodConf):
     class Doorbell(BaseModel):
         name: str = Field(description="Custom name of the doorbell")
         ip: str
+        port: Optional[int] = 8000
         username: str
         password: str
         output_relays: Optional[int] = None   # TODO: validate it is in acceppable range!
@@ -86,7 +87,7 @@ class AppConfig(GoodConf):
 
     class MQTT(BaseModel):
         host: str
-        port: int = 1883
+        port: Optional[int] = 1883
         ssl: Optional[bool] = Field(default=False, description="Set to true to enable SSL")
         username: Optional[str] = None
         password: Optional[str] = None

--- a/hikvision-doorbell/src/doorbell.py
+++ b/hikvision-doorbell/src/doorbell.py
@@ -51,7 +51,7 @@ class Doorbell():
         self._device_info = NET_DVR_DEVICEINFO_V30()
         self.user_id = self._sdk.NET_DVR_Login_V30(
             bytes(self._config.ip, 'utf8'),
-            8000,
+            self._config.port,
             bytes(self._config.username, 'utf8'),
             bytes(self._config.password, 'utf8'),
             self._device_info

--- a/hikvision-doorbell/src/mqtt.py
+++ b/hikvision-doorbell/src/mqtt.py
@@ -93,6 +93,7 @@ class MQTTHandler(EventHandler):
         # Save the MQTT settings as an attribute
         self._mqtt_settings = Settings.MQTT(
             host=config.host,
+            port=config.port,
             username=config.username,
             password=config.password
         )


### PR DESCRIPTION
Hey @mion00  , created this PR, can you have a look?
Added optional port for hikvisin devices, for users not using 8000 => i think this one is OK
Added option for docker users to define an mqtt port, default is 1883 now, but for some reason, if i change in my environment like below "9999",  it still uses "1883" , somewhere its still hardcoded?

```
# Connection to MQTT broker
MQTT__HOST=192.168.0.17
# Optionals:
MQTT__PORT=9999
MQTT__USERNAME=xx
MQTT__PASSWORD=yy
```