### PR TITLE
Feat / Mute and unmute doorbell

### DIFF
--- a/hikvision-doorbell/DOCS.md
+++ b/hikvision-doorbell/DOCS.md
@@ -154,24 +154,26 @@ The input string must be in the format
 ```
 - `<command>` is one of:
 
-  | Command     | Description                                               |
-  | --------    | ----                                                      |
-  | unlock      | Unlock the specified door (`<optional_parameter>` must be `1` or `2`) connected to the doorbell station output relay
-  | reboot      | Reboot the specified  door station
-  | reject      | Reject the incoming call and stop the indoor stations from ringing
-  | request     | Unknown
-  | cancel      | Unknown
-  | answer      | Unknown
-  | reject      | Unknown
-  | bellTimeout | Unknown
-  | hangUp      | Unknown
-  | deviceOnCall| Unknown
-  | atHome      | Sending scene "At home" for indoor panels
-  | goOut       | Sending scene "Go out" for indoor panels
-  | goToBed     | Sending scene "Go to bed" for indoor panels
-  | custom      | Sending scene "custom" for indoor panels
-  | setupAlarm  | Turn on the alarm on the indoor panel
-  | closeAlarm  | Turn off the alarm on the indoor panel
+  | Command           | Description                                               |
+  | --------          | ----                                                      |
+  | unlock            | Unlock the specified door (`<optional_parameter>` must be `1` or `2`) connected to the doorbell station output relay
+  | reboot            | Reboot the specified  door station
+  | reject            | Reject the incoming call and stop the indoor stations from ringing
+  | request           | Unknown
+  | cancel            | Unknown
+  | answer            | Unknown
+  | reject            | Unknown
+  | bellTimeout       | Unknown
+  | hangUp            | Unknown
+  | deviceOnCall      | Unknown
+  | atHome            | Sending scene "At home" for indoor panels
+  | goOut             | Sending scene "Go out" for indoor panels
+  | goToBed           | Sending scene "Go to bed" for indoor panels
+  | custom            | Sending scene "custom" for indoor panels
+  | setupAlarm        | Turn on the alarm on the indoor panel
+  | closeAlarm        | Turn off the alarm on the indoor panel
+  | muteAudioOutput   | Mutes the audio output of the doorbell / indoor station
+  | unmuteAudioOutput | Unmutes the audio output of the doorbell / indoor station
 - `<doorbell_name>` is the custom name given to the doorbell in the configuration options, all lowercase and with whitespace substituted by underscores `_`. 
 
   E.G.: If the doorbell is named `Front door`, the input string must reference it as `front_door`.

--- a/hikvision-doorbell/src/input.py
+++ b/hikvision-doorbell/src/input.py
@@ -149,6 +149,12 @@ class InputReader():
             case "reboot":
                 logger.info("Rebooting door station")
                 doorbell.reboot_device()
+            case "muteAudioOutput":
+                logger.info("Mute audio output")
+                doorbell.mute_audio_output()
+            case "unmuteAudioOutput":
+                logger.info("Unmute audio output")
+                doorbell.unmute_audio_output()
             case "debug":
                 # This is a special command that accept the name of a method,
                 # calls the method on the doorbell instance and outputs the result

--- a/hikvision-doorbell/src/mqtt_input.py
+++ b/hikvision-doorbell/src/mqtt_input.py
@@ -88,6 +88,30 @@ class MQTTInput():
             answer_button.set_availability(True)
 
             ###########
+            # Mute audio output button
+            button_info = ButtonInfo(
+                name="Mute audio output",
+                unique_id=f"{sanitized_doorbell_name}_mute_audio_output",
+                device=device,
+                icon="mdi:volume-mute",
+                object_id=f"{sanitized_doorbell_name}_mute_audio_output")
+            settings = Settings(mqtt=mqtt_settings, entity=button_info, manual_availability=True)
+            mute_button = Button(settings, self._mute_audio_output_callback, doorbell)
+            mute_button.set_availability(True)
+
+            ###########
+            # Unmute audio output button
+            button_info = ButtonInfo(
+                name="Unmute audio output",
+                unique_id=f"{sanitized_doorbell_name}_unmute_audio_output",
+                device=device,
+                icon="mdi:volume-high",
+                object_id=f"{sanitized_doorbell_name}_unmute_audio_output")
+            settings = Settings(mqtt=mqtt_settings, entity=button_info, manual_availability=True)
+            unmute_button = Button(settings, self._unmute_audio_output_callback, doorbell)
+            unmute_button.set_availability(True)
+
+            ###########
             # ISAPI request input text
             text_info = TextInfo(
                 name="ISAPI request",
@@ -409,6 +433,22 @@ class MQTTInput():
             doorbell._call_isapi("PUT", url, requestBody)
             alarm_sensor = cast(Sensor, self._sensors[doorbell]['alarm_sensor'])
             alarm_sensor.set_state("closeAlarm")
+        except SDKError as err:
+            logger.error("Error setting scene: {}", err)
+
+    def _mute_audio_output_callback(self, client, doorbell: Doorbell, message: MQTTMessage):
+        logger.info("Received mute audio output command for doorbell: {}", doorbell._config.name)
+
+        try:
+            doorbell.mute_audio_output()
+        except SDKError as err:
+            logger.error("Error setting scene: {}", err)
+
+    def _unmute_audio_output_callback(self, client, doorbell: Doorbell, message: MQTTMessage):
+        logger.info("Received unmute audio output command for doorbell: {}", doorbell._config.name)
+
+        try:
+            doorbell.unmute_audio_output()
         except SDKError as err:
             logger.error("Error setting scene: {}", err)
 


### PR DESCRIPTION
Hi,

since my indoor station doesn't support answering a call ([see issue #149](https://github.com/pergolafabio/Hikvision-Addons/issues/149)) i pursued the approach to mute the outdoor station, reject the call and unmute the outdoor station to avoid the nasty reject call sound on the outdoor station.

I analysed the communication between the iVMS Client and my KD8003 while modifying the audio output of the outdoor station in the iVMS Client and found out that the iVMS Client sends a PUT request to "/ISAPI/System/Audio/AudioOut/channels/1" with the following payload:

`<AudioOut><id>1</id><AudioOutVolumelist><AudioOutVlome><type>audioOutput</type><volume>0</volume><talkVolume>5</talkVolume></AudioOutVlome></AudioOutVolumelist</AudioOut>`

Using this i implemented a mute and unmute button / command for the audio output of a doorbell in your addon. It works for both, the outdoor station (KD8003) and the indoor station (KH8520)

Would be awsome if you accept the pull request :-)

