### PR TITLE
Add SDK session watchdog for automatic recovery from stale connections

### DIFF
--- a/hikvision-doorbell/src/doorbell.py
+++ b/hikvision-doorbell/src/doorbell.py
@@ -64,6 +64,8 @@ class Doorbell():
     '''Populated after authenticate method is invoked'''
     _previouse_audio_out_volume: str
     '''Used to unmute the doorbell by changing the audio out volume from 0 to the previouse value '''
+    _alarm_handle: int
+    '''Handle returned by setup_alarm, used for health monitoring and teardown'''
 
     def __init__(self, id: int, config: AppConfig.Doorbell, sdk: CDLL):
         """
@@ -75,6 +77,7 @@ class Doorbell():
         self._config = config
         self._id = id
         self._previouse_audio_out_volume = "5"
+        self._alarm_handle = -1
 
     def authenticate(self):
         '''Authenticate with the remote doorbell'''
@@ -113,10 +116,25 @@ class Doorbell():
         alarm_param.bySupport = alarm_param.bySupport & ~0x02
 
         logger.debug("Arming the device via SDK")
-        alarm_handle = self._sdk.NET_DVR_SetupAlarmChan_V50(
+        self._alarm_handle = self._sdk.NET_DVR_SetupAlarmChan_V50(
             self.user_id, alarm_param, None, 0)
-        if alarm_handle < 0:
+        if self._alarm_handle < 0:
             raise SDKError(self._sdk, f"Error while listening to events in {self._config.name}")
+
+    def close_alarm(self):
+        '''Tear down the alarm channel. Safe to call even if not armed.'''
+        if self._alarm_handle >= 0:
+            self._sdk.NET_DVR_CloseAlarmChan_V30(self._alarm_handle)
+            self._alarm_handle = -1
+
+    def is_session_active(self) -> bool:
+        '''Lightweight probe: attempt a minimal SDK call to verify the login session is still valid.
+        Returns True if the session responds, False otherwise.'''
+        try:
+            self._call_isapi("GET", "/ISAPI/System/deviceInfo")
+            return True
+        except SDKError:
+            return False
 
     def logout(self):
         logout_result = self._sdk.NET_DVR_Logout_V30(self.user_id)

--- a/hikvision-doorbell/src/event.py
+++ b/hikvision-doorbell/src/event.py
@@ -188,8 +188,10 @@ class EventManager:
             return callback_alarm_info_p
 
     async def _invoke_handlers(self, command, device: NET_DVR_ALARMER, alarm_info, buffer_length, user_pointer):
-        # Match the device information from the callback with a Doorbell instance in the registry
         doorbell = self._doorbells.getBySerialNumber(device.serialNumber())
+        if doorbell is None:
+            logger.warning("Received event from unregistered device (serial: {}), skipping", device.serialNumber())
+            return
         logger.debug("Invoking {} handlers", len(self._handlers))
         for handler in self._handlers:
 

--- a/hikvision-doorbell/src/main.py
+++ b/hikvision-doorbell/src/main.py
@@ -21,7 +21,7 @@ from input import InputReader
 async def retry_connection(index, doorbell_config, sdk, doorbell_registry, mqtt_handler=None):
     """Background task that retries connection for a specific doorbell indefinitely"""
     while True:
-        await asyncio.sleep(30) # Wait 30 seconds before retrying
+        await asyncio.sleep(30)
         if index not in doorbell_registry:
             try:
                 logger.info(f"Retrying connection for {doorbell_config.name} (Index {index})...")
@@ -31,24 +31,89 @@ async def retry_connection(index, doorbell_config, sdk, doorbell_registry, mqtt_
 
                 doorbell_registry[index] = doorbell
 
-                
                 if mqtt_handler:
                     logger.info(f"Refreshing MQTT discovery for {doorbell_config.name}")
-                    # This triggers the discovery/online message in HA
                     if hasattr(mqtt_handler, '_call_sensor_tasks'):
                         for task in mqtt_handler._call_sensor_tasks.values():
                             task.cancel()
                         mqtt_handler._call_sensor_tasks.clear()
-                    
+
                     mqtt_handler.__init__(mqtt_handler._mqtt_settings, doorbell_registry)
 
                     from mqtt_input import MQTTInput
                     MQTTInput(mqtt_handler._mqtt_settings, doorbell_registry)
 
                 logger.info(f"Doorbell {doorbell_config.name} is now ONLINE and armed.")
-                break # Exit the loop once connected
+                break
             except Exception as e:
                 logger.warning(f"Retry for {doorbell_config.name} failed: {e}")
+
+
+async def watchdog(doorbell_configs, sdk, doorbell_registry, mqtt_handler=None, interval=120):
+    """Periodically verify that every registered doorbell session is still alive.
+    If a session has gone stale, tear it down and re-authenticate + re-arm.
+
+    Uses a lightweight ISAPI probe (/ISAPI/System/deviceInfo) which is already
+    cached by the device firmware, so the overhead is negligible.
+
+    Args:
+        doorbell_configs: list of AppConfig.Doorbell from the original configuration
+        sdk: loaded HCNetSDK instance
+        doorbell_registry: shared Registry of active Doorbell objects
+        mqtt_handler: optional MQTTHandler for MQTT re-init on recovery
+        interval: seconds between health checks (default 120)
+    """
+    await asyncio.sleep(interval)
+    consecutive_failures: dict[int, int] = {}
+
+    while True:
+        for index, doorbell in list(doorbell_registry.items()):
+            try:
+                if doorbell.is_session_active():
+                    consecutive_failures[index] = 0
+                    continue
+
+                consecutive_failures[index] = consecutive_failures.get(index, 0) + 1
+                logger.warning(
+                    "Doorbell {} ({}) session is stale (attempt {}), recovering...",
+                    index, doorbell._config.name, consecutive_failures[index])
+
+                doorbell.close_alarm()
+                try:
+                    doorbell.logout()
+                except Exception:
+                    pass
+
+                del doorbell_registry[index]
+
+                new_doorbell = Doorbell(index, doorbell_configs[index], sdk)
+                new_doorbell.authenticate()
+                new_doorbell.setup_alarm()
+                doorbell_registry[index] = new_doorbell
+
+                if mqtt_handler:
+                    logger.info("Re-initializing MQTT entities for {}", doorbell_configs[index].name)
+                    if hasattr(mqtt_handler, '_call_sensor_tasks'):
+                        for task in mqtt_handler._call_sensor_tasks.values():
+                            task.cancel()
+                        mqtt_handler._call_sensor_tasks.clear()
+                    mqtt_handler.__init__(mqtt_handler._mqtt_settings, doorbell_registry)
+                    from mqtt_input import MQTTInput
+                    MQTTInput(mqtt_handler._mqtt_settings, doorbell_registry)
+
+                consecutive_failures[index] = 0
+                logger.info("Doorbell {} ({}) recovered successfully", index, doorbell_configs[index].name)
+
+            except Exception as e:
+                fail_count = consecutive_failures.get(index, 1)
+                backoff = min(interval * (2 ** (fail_count - 1)), 600)
+                logger.error(
+                    "Recovery failed for doorbell {} ({}): {}. Next attempt in {}s",
+                    index, doorbell_configs[index].name, e, backoff)
+                await asyncio.sleep(backoff)
+                continue
+
+        await asyncio.sleep(interval)
 
 async def main():
     """Main entrypoint of the application"""
@@ -230,6 +295,11 @@ async def main():
             del doorbell_registry[index]
             # Also start retry if arming fails
             asyncio.create_task(retry_connection(index, config.doorbells[index], sdk, doorbell_registry, mqtt_inst))
+
+    # Start the session watchdog to detect and recover from stale SDK connections
+    asyncio.create_task(
+        watchdog(config.doorbells, sdk, doorbell_registry, mqtt_inst),
+        name="SDK session watchdog")
 
     # Create reader to receive commands from STDIN
     input_reader = InputReader(doorbell_registry)

--- a/hikvision-doorbell/src/sdk/utils.py
+++ b/hikvision-doorbell/src/sdk/utils.py
@@ -127,11 +127,9 @@ def call_ISAPI(sdk: CDLL, user_id: int, http_method: str, url: str, requestBody:
     # Input information
     inputStruct = NET_DVR_XML_CONFIG_INPUT()
 
-    urlSize = (c_char * 256)()
-
     requestUrlBuffer = bytes(inUrl, "ascii")
     inputStruct.lpRequestUrl = cast(c_char_p(requestUrlBuffer), c_void_p)
-    inputStruct.dwRequestUrlLen = len(urlSize)
+    inputStruct.dwRequestUrlLen = len(requestUrlBuffer)
 
     inputBuffer = bytes(requestBody, "ascii")
 


### PR DESCRIPTION
## Problem

The Hikvision SDK maintains persistent TCP sessions to each doorbell via `NET_DVR_Login_V30` and `NET_DVR_SetupAlarmChan_V50`. These sessions can silently become stale after network disruptions, device reboots, or firmware-level timeouts.

When this happens, the addon stops receiving SDK alarm callbacks and therefore stops publishing to MQTT — while the container process keeps running with no errors logged. The only fix is a manual restart.

This is a long-standing reliability issue that affects anyone running the addon for extended periods (typically fails after 12-48 hours).

## Root Cause

1. The alarm handle returned by `NET_DVR_SetupAlarmChan_V50()` was never stored — no way to check health, close, or reopen it
2. No periodic health check on the SDK login session
3. `retry_connection()` only handles startup failures, not sessions that go stale during normal operation
4. `main_loop()` only restarts on exceptions, but in steady state `main()` blocks on stdin and never raises

## Solution

### 1. Session watchdog (`main.py`)

A background asyncio task that periodically probes each doorbell with a lightweight ISAPI call (`/ISAPI/System/deviceInfo`). On failure:
- Tears down the stale alarm channel
- Logs out the dead session
- Re-authenticates and re-arms the doorbell
- Re-initializes MQTT entities

Uses exponential backoff (capped at 600s) for repeated recovery failures. Default check interval is 120 seconds — negligible overhead since `deviceInfo` is cached by the device firmware.

### 2. Alarm handle lifecycle (`doorbell.py`)

- Store the handle returned by `NET_DVR_SetupAlarmChan_V50()` in `_alarm_handle`
- Add `close_alarm()` for proper teardown via `NET_DVR_CloseAlarmChan_V30` before re-arming
- Add `is_session_active()` as a lightweight health probe for the watchdog

### 3. Null guard in event dispatch (`event.py`)

`_invoke_handlers` now checks for `None` when resolving the doorbell by serial number, preventing silent task exceptions when the registry is temporarily out of sync during recovery.

### 4. ISAPI URL length fix (`sdk/utils.py`)

`dwRequestUrlLen` was always set to 256 (the buffer capacity) instead of the actual URL length. Now correctly uses `len(requestUrlBuffer)`.

## Testing

Deployed and tested on a live setup with 3 Hikvision devices (DS-KD8003-IME1 outdoor + 2 indoor stations) running via Podman on Fedora. The watchdog correctly detects and recovers from simulated session failures, and normal operation (events, MQTT publishing, ISAPI polling) is unaffected.