### PR TITLE
Add online connectivity sensor (SDK reconnect-based)

### DIFF
--- a/hikvision-doorbell/src/main.py
+++ b/hikvision-doorbell/src/main.py
@@ -12,6 +12,16 @@ from event import ConsoleHandler, EventManager
 from mqtt import MQTTHandler
 from mqtt_input import MQTTInput
 from config import mqtt_config_from_supervisor
+from sdk.hcnetsdk import (
+    ALARM_RECONNECTSUCCESS,
+    EXCEPTION_ALARM,
+    EXCEPTION_ALARMRECONNECT,
+    EXCEPTION_EXCHANGE,
+    EXCEPTION_PREVIEW,
+    EXCEPTION_RECONNECT,
+    PREVIEW_RECONNECTSUCCESS,
+    fExceptionCallBack,
+)
 from sdk.utils import SDKConfig, SDKError, loadSDK, setupSDK, shutdownSDK
 from loguru import logger
 
@@ -49,6 +59,60 @@ async def retry_connection(index, doorbell_config, sdk, doorbell_registry, mqtt_
                 break # Exit the loop once connected
             except Exception as e:
                 logger.warning(f"Retry for {doorbell_config.name} failed: {e}")
+
+
+def make_exception_callback(doorbell_registry: Registry, mqtt_handler):
+    """Build the SDK exception callback that mirrors connection state into MQTT.
+
+    The Hikvision SDK auto-reconnects internally; we just listen and update the
+    "Online state" binary sensor accordingly. Exception codes signal a drop
+    (alarm/preview channel down, login lost, reconnect attempts in progress);
+    *_RECONNECTSUCCESS codes signal the channel is back. See sdk.hcnetsdk for
+    code definitions sourced from HCNetSDK.h.
+
+    The SDK invokes this from a non-asyncio worker thread, so the callback must
+    not touch the event loop. ha_mqtt_discoverable's BinarySensor.on()/off()
+    publish synchronously over MQTT, which is thread-safe.
+    """
+    DISCONNECT_CODES = (
+        EXCEPTION_EXCHANGE, EXCEPTION_ALARM, EXCEPTION_PREVIEW,
+        EXCEPTION_RECONNECT, EXCEPTION_ALARMRECONNECT,
+    )
+    RECONNECT_SUCCESS_CODES = (PREVIEW_RECONNECTSUCCESS, ALARM_RECONNECTSUCCESS)
+
+    def _callback(dwType, lUserID, lHandle, pUser):
+        # Map the SDK user_id back to our doorbell index. The SDK only knows
+        # about user_ids it returned from NET_DVR_Login_V40; we keep our own
+        # zero-based index for MQTT entity addressing.
+        index = None
+        for idx, doorbell in doorbell_registry.items():
+            if getattr(doorbell, 'user_id', None) == lUserID:
+                index = idx
+                break
+        if index is None:
+            logger.debug("SDK exception 0x{:X} for unknown user_id {} (no doorbell mapped)",
+                         dwType, lUserID)
+            return
+
+        if dwType in DISCONNECT_CODES:
+            logger.warning("Doorbell {} disconnected (SDK exception 0x{:X}); marking offline",
+                           index, dwType)
+            if mqtt_handler is not None:
+                mqtt_handler.set_doorbell_offline(index)
+        elif dwType in RECONNECT_SUCCESS_CODES:
+            logger.info("Doorbell {} reconnected (SDK code 0x{:X}); marking online",
+                        index, dwType)
+            if mqtt_handler is not None:
+                mqtt_handler.set_doorbell_online(index)
+        else:
+            # Other exception codes exist (disk format, email test, etc.) but
+            # are not connectivity-related. Log at debug so unexpected codes
+            # are visible without spamming the log.
+            logger.debug("SDK exception 0x{:X} for doorbell {} (no state change)",
+                         dwType, index)
+
+    return fExceptionCallBack(_callback)
+
 
 async def main():
     """Main entrypoint of the application"""
@@ -225,11 +289,25 @@ async def main():
     for index, doorbell in list(doorbell_registry.items()):
         try:
             doorbell.setup_alarm()
+            if mqtt_inst:
+                mqtt_inst.set_doorbell_online(index)
         except Exception as e:
             logger.error(f"Failed to arm doorbell {index}: {e}")
             del doorbell_registry[index]
+            if mqtt_inst:
+                mqtt_inst.set_doorbell_offline(index)
             # Also start retry if arming fails
             asyncio.create_task(retry_connection(index, config.doorbells[index], sdk, doorbell_registry, mqtt_inst))
+
+    # Register the SDK exception callback. The SDK fires it from a worker
+    # thread on connection drops, reconnect attempts, and reconnect success;
+    # we mirror those events into the "Online state" MQTT sensor. The SDK
+    # handles the actual reconnect work — we just observe.
+    exception_cb = make_exception_callback(doorbell_registry, mqtt_inst)
+    sdk.NET_DVR_SetExceptionCallBack_V30(0, None, exception_cb, None)
+    # Hold a strong reference so the ctypes-wrapped Python callback isn't
+    # garbage-collected while the SDK still holds the function pointer.
+    main._exception_cb_ref = exception_cb
 
     # Create reader to receive commands from STDIN
     input_reader = InputReader(doorbell_registry)

--- a/hikvision-doorbell/src/mqtt.py
+++ b/hikvision-doorbell/src/mqtt.py
@@ -162,6 +162,9 @@ class MQTTHandler(EventHandler):
 
             ##################
             # Online state
+            # Reflects whether the doorbell is reachable. Driven by main.py via
+            # the SDK exception callback (set_doorbell_online/offline). Starts
+            # off; flipped on once setup_alarm() succeeds during startup.
             online_sensor_info = BinarySensorInfo(
                 name="Online state",
                 unique_id=f"{device.identifiers}-online_state",
@@ -633,18 +636,27 @@ class MQTTHandler(EventHandler):
         device_trigger.trigger(json_payload)
 
     def _get_sensors_by_id(self, doorbell_id: int) -> Optional[dict]:
+        """Look up the sensors dict by doorbell._id.
+
+        Used because the Doorbell *object* may be replaced on reconnect (a new
+        instance is created by retry_connection), but the integer _id stays
+        stable. Iterating by _id keeps the MQTT sensor reference intact across
+        Doorbell-object swaps.
+        """
         for doorbell, sensors in self._sensors.items():
             if doorbell._id == doorbell_id:
                 return sensors
         return None
 
     def set_doorbell_online(self, doorbell_id: int):
+        """Flip the connectivity binary sensor to ON for the given doorbell."""
         sensors = self._get_sensors_by_id(doorbell_id)
         if sensors:
             cast(BinarySensor, sensors['online_state']).on()
             logger.info("Doorbell {} marked online in MQTT", doorbell_id)
 
     def set_doorbell_offline(self, doorbell_id: int):
+        """Flip the connectivity binary sensor to OFF for the given doorbell."""
         sensors = self._get_sensors_by_id(doorbell_id)
         if sensors:
             cast(BinarySensor, sensors['online_state']).off()

--- a/hikvision-doorbell/src/mqtt.py
+++ b/hikvision-doorbell/src/mqtt.py
@@ -160,6 +160,21 @@ class MQTTHandler(EventHandler):
             call_sensor.set_availability(True)
             self._sensors[doorbell]['call'] = call_sensor
 
+            ##################
+            # Online state
+            online_sensor_info = BinarySensorInfo(
+                name="Online state",
+                unique_id=f"{device.identifiers}-online_state",
+                device=device,
+                device_class="connectivity",
+                default_entity_id=f"{sanitized_doorbell_name}_online_state")
+
+            settings = Settings(mqtt=self._mqtt_settings, entity=online_sensor_info, manual_availability=True)
+            online_sensor = BinarySensor(settings)
+            online_sensor.off()
+            online_sensor.set_availability(True)
+            self._sensors[doorbell]['online_state'] = online_sensor
+
             # If polling is defined, create a loop to update the call state periodically
 
             if not doorbell._config.call_state_poll is None:
@@ -616,6 +631,24 @@ class MQTTHandler(EventHandler):
         # Serialize the payload, if provided as part of the trigger
         json_payload = json.dumps(trigger['payload']) if trigger.get('payload') else None
         device_trigger.trigger(json_payload)
+
+    def _get_sensors_by_id(self, doorbell_id: int) -> Optional[dict]:
+        for doorbell, sensors in self._sensors.items():
+            if doorbell._id == doorbell_id:
+                return sensors
+        return None
+
+    def set_doorbell_online(self, doorbell_id: int):
+        sensors = self._get_sensors_by_id(doorbell_id)
+        if sensors:
+            cast(BinarySensor, sensors['online_state']).on()
+            logger.info("Doorbell {} marked online in MQTT", doorbell_id)
+
+    def set_doorbell_offline(self, doorbell_id: int):
+        sensors = self._get_sensors_by_id(doorbell_id)
+        if sensors:
+            cast(BinarySensor, sensors['online_state']).off()
+            logger.warning("Doorbell {} marked offline in MQTT", doorbell_id)
 
 def get_mqtt_handler():
     """Get the current MQTTHandler instance"""

--- a/hikvision-doorbell/src/sdk/hcnetsdk.py
+++ b/hikvision-doorbell/src/sdk/hcnetsdk.py
@@ -795,3 +795,20 @@ class MessageCallbackAlarmInfoUnion(Union):
 fMessageCallBack = CFUNCTYPE(BOOL, LONG, POINTER(
     NET_DVR_ALARMER), POINTER(MessageCallbackAlarmInfoUnion), DWORD, c_void_p)
 
+# Hikvision SDK exception/reconnect codes delivered to NET_DVR_SetExceptionCallBack_V30.
+# Values taken from the official HCNetSDK.h header (mirrored at
+# https://github.com/Chise1/pyhk/blob/master/hcn_define.h). Do NOT derive these
+# from runtime observation — different firmware revisions emit different codes
+# and the header is the authoritative source.
+EXCEPTION_EXCHANGE = 0x8000           # Login session exception (user exchange)
+EXCEPTION_ALARM = 0x8002              # Alarm channel exception
+EXCEPTION_PREVIEW = 0x8003            # Preview channel exception
+EXCEPTION_RECONNECT = 0x8005          # Preview channel attempting reconnect
+EXCEPTION_ALARMRECONNECT = 0x8006     # Alarm channel attempting reconnect
+PREVIEW_RECONNECTSUCCESS = 0x8015     # Preview channel reconnected successfully
+ALARM_RECONNECTSUCCESS = 0x8016       # Alarm channel reconnected successfully
+
+# Function pointer signature for NET_DVR_SetExceptionCallBack_V30:
+#   void (*fExceptionCallBack)(DWORD dwType, LONG lUserID, LONG lHandle, void *pUser)
+fExceptionCallBack = CFUNCTYPE(None, DWORD, LONG, LONG, c_void_p)
+

--- a/hikvision-doorbell/tests/test_main.py
+++ b/hikvision-doorbell/tests/test_main.py
@@ -1,0 +1,119 @@
+"""Tests for the SDK-driven connectivity callback in main.py."""
+import sys
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from doorbell import Registry  # noqa: E402
+from main import make_exception_callback  # noqa: E402
+from sdk.hcnetsdk import (  # noqa: E402
+    ALARM_RECONNECTSUCCESS,
+    EXCEPTION_ALARM,
+    EXCEPTION_ALARMRECONNECT,
+    EXCEPTION_EXCHANGE,
+    EXCEPTION_PREVIEW,
+    EXCEPTION_RECONNECT,
+    PREVIEW_RECONNECTSUCCESS,
+)
+
+
+def _make_doorbell(mocker: MockerFixture, doorbell_id: int, user_id: int):
+    d = mocker.MagicMock()
+    d._id = doorbell_id
+    d.user_id = user_id
+    return d
+
+
+class TestExceptionCallback:
+
+    def test_alarm_reconnect_marks_offline(self, mocker: MockerFixture):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=42)
+        handler = mocker.MagicMock()
+
+        cb = make_exception_callback(registry, handler)
+        cb(EXCEPTION_ALARMRECONNECT, 42, 0, None)
+
+        handler.set_doorbell_offline.assert_called_once_with(0)
+        handler.set_doorbell_online.assert_not_called()
+
+    def test_reconnect_success_marks_online(self, mocker: MockerFixture):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=42)
+        handler = mocker.MagicMock()
+
+        cb = make_exception_callback(registry, handler)
+        cb(ALARM_RECONNECTSUCCESS, 42, 0, None)
+
+        handler.set_doorbell_online.assert_called_once_with(0)
+        handler.set_doorbell_offline.assert_not_called()
+
+    @pytest.mark.parametrize("ok_type", [PREVIEW_RECONNECTSUCCESS, ALARM_RECONNECTSUCCESS])
+    def test_all_reconnect_codes_mark_online(self, mocker: MockerFixture, ok_type):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=42)
+        handler = mocker.MagicMock()
+
+        cb = make_exception_callback(registry, handler)
+        cb(ok_type, 42, 0, None)
+
+        handler.set_doorbell_online.assert_called_once_with(0)
+
+    @pytest.mark.parametrize("exc_type", [
+        EXCEPTION_EXCHANGE, EXCEPTION_ALARM, EXCEPTION_PREVIEW,
+        EXCEPTION_RECONNECT, EXCEPTION_ALARMRECONNECT,
+    ])
+    def test_all_disconnect_exceptions_mark_offline(self, mocker: MockerFixture, exc_type):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=42)
+        handler = mocker.MagicMock()
+
+        cb = make_exception_callback(registry, handler)
+        cb(exc_type, 42, 0, None)
+
+        handler.set_doorbell_offline.assert_called_once_with(0)
+
+    def test_unknown_user_id_does_nothing(self, mocker: MockerFixture):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=42)
+        handler = mocker.MagicMock()
+
+        cb = make_exception_callback(registry, handler)
+        cb(EXCEPTION_ALARMRECONNECT, 999, 0, None)
+
+        handler.set_doorbell_offline.assert_not_called()
+        handler.set_doorbell_online.assert_not_called()
+
+    def test_no_mqtt_handler_does_not_crash(self, mocker: MockerFixture):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=42)
+
+        cb = make_exception_callback(registry, None)
+        cb(EXCEPTION_ALARMRECONNECT, 42, 0, None)
+        cb(ALARM_RECONNECTSUCCESS, 42, 0, None)
+
+    def test_unknown_exception_type_no_state_change(self, mocker: MockerFixture):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=42)
+        handler = mocker.MagicMock()
+
+        cb = make_exception_callback(registry, handler)
+        cb(0xDEAD, 42, 0, None)
+
+        handler.set_doorbell_offline.assert_not_called()
+        handler.set_doorbell_online.assert_not_called()
+
+    def test_maps_correct_doorbell_among_many(self, mocker: MockerFixture):
+        registry = Registry()
+        registry[0] = _make_doorbell(mocker, doorbell_id=0, user_id=10)
+        registry[1] = _make_doorbell(mocker, doorbell_id=1, user_id=20)
+        registry[2] = _make_doorbell(mocker, doorbell_id=2, user_id=30)
+        handler = mocker.MagicMock()
+
+        cb = make_exception_callback(registry, handler)
+        cb(EXCEPTION_ALARMRECONNECT, 20, 0, None)
+
+        handler.set_doorbell_offline.assert_called_once_with(1)


### PR DESCRIPTION
## ⚠️ PR Repurposed

This PR was originally bundled with door relay fallback and last-unlocked timestamp sensor. Those have been split into separate PRs:

- Door relay fallback → PR #347
- Last-unlocked timestamp sensor → PR #348

This PR now focuses solely on the online connectivity sensor.

---

## ⚠️ AI-Generated Code

This change was authored with AI assistance. It has been tested locally on a real device (DS-KH6320-WTE1, firmware V2.2.108) — disconnect and reconnect events flip the sensor as expected — but please review carefully before merging.

## Summary
Adds an MQTT binary sensor reflecting doorbell connectivity. Driven by the SDK's `NET_DVR_SetExceptionCallBack_V30` (per Fabio's suggestion) instead of ISAPI polling — the SDK already auto-reconnects internally; we just mirror its state.

## How it works
- Register an exception callback at startup
- SDK fires the callback with `dwType` codes from `HCNetSDK.h`:
  - `EXCEPTION_EXCHANGE / ALARM / PREVIEW / RECONNECT / ALARMRECONNECT` → mark offline
  - `PREVIEW_RECONNECTSUCCESS / ALARM_RECONNECTSUCCESS` → mark online
- Map `lUserID` → doorbell index → MQTT `online_state` binary sensor

Constants are taken from the official Hikvision header (HCNetSDK.h), not from runtime observation, so the mapping is firmware-agnostic.

## Test
- 13 new unit tests (`tests/test_main.py`) covering: every disconnect code, both reconnect codes, unknown user_id, missing handler, unknown code, multi-doorbell mapping
- Verified live: doorbell reboot triggers `0x8006 → offline`, `0x8016 → online` in logs