### PR TITLE
Add fallback door relay when device reports zero outputs

### DIFF
--- a/hikvision-doorbell/src/mqtt.py
+++ b/hikvision-doorbell/src/mqtt.py
@@ -204,8 +204,11 @@ class MQTTHandler(EventHandler):
                 num_doors = doorbell.get_num_outputs()
             else:
                 num_doors = doorbell.get_num_outputs_indoor()
-            logger.debug("Configuring {} door switches", num_doors)
-            for door_id in range(num_doors):
+            num_doors_to_configure = max(num_doors, 1)
+            if num_doors == 0:
+                logger.debug("No door relays discovered, creating 1 fallback switch")
+            logger.debug("Configuring {} door switches", num_doors_to_configure)
+            for door_id in range(num_doors_to_configure):
                 door_switch_info = SwitchInfo(
                     name=f"Door {door_id+1} relay",
                     unique_id=f"{device.identifiers}-door_relay_{door_id}",

--- a/hikvision-doorbell/tests/test_mqtt.py
+++ b/hikvision-doorbell/tests/test_mqtt.py
@@ -179,3 +179,37 @@ class TestDeviceTrigger:
 
         asyncio.run(handler.video_intercom_alarm(mocked_doorbell, 0, None, video_intercom_alarm, 0, None))
     '''
+
+
+class TestDoorRelayFallback:
+
+    def _build_handler(self, mocker: MockerFixture, num_outputs: int) -> tuple[MQTTHandler, Doorbell]:
+        mocked_doorbell = mocker.patch('doorbell.Doorbell')
+        mocked_doorbell._id = 0
+        mocked_doorbell._type = DeviceType.OUTDOOR
+        mocked_doorbell._config.name = "Test doorbell"
+        mocked_doorbell._device_info.serialNumber = lambda: "123"
+        mocked_doorbell.get_num_outputs.return_value = num_outputs
+
+        registry = Registry()
+        registry[0] = mocked_doorbell
+
+        extract_device_info = mocker.patch('mqtt.extract_device_info', autospec=True)
+        extract_device_info.return_value = DeviceInfo(name="Outdoor unit", identifiers="id")
+
+        mocker.patch("mqtt.BinarySensor")
+        mocker.patch("mqtt.Sensor")
+        mocker.patch("mqtt.Switch")
+        mocker.patch("mqtt.DeviceTrigger")
+
+        handler = MQTTHandler(AppConfig.MQTT(host="localhost"), registry)
+        return handler, mocked_doorbell
+
+    def test_fallback_switch_created_when_no_relays(self, mocker: MockerFixture):
+        handler, mocked_doorbell = self._build_handler(mocker, num_outputs=0)
+        assert 'door_0' in handler._sensors[mocked_doorbell]
+
+    def test_no_extra_switch_when_one_relay_discovered(self, mocker: MockerFixture):
+        handler, mocked_doorbell = self._build_handler(mocker, num_outputs=1)
+        assert 'door_0' in handler._sensors[mocked_doorbell]
+        assert 'door_1' not in handler._sensors[mocked_doorbell]


### PR DESCRIPTION
## Summary
Some indoor/outdoor units return 0 door outputs from `get_num_outputs()` / `get_num_outputs_indoor()`, so no door relay switch is created and the user has no way to unlock the door from Home Assistant.

This PR adds a single fallback switch (`Door 1 relay`) when the device reports 0 outputs, so the unlock action is still exposed.

## Changes
- `mqtt.py`: if `num_doors == 0`, configure 1 switch instead of skipping.